### PR TITLE
feat: auto merge patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,11 +20,6 @@ updates:
         applies-to: version-updates
         update-types:
           - "patch"
-        exclude-patterns:
-          - "@aws-sdk/*"
-          - "aws-cdk*"
-          - "cdk"
-          - "constructs"
       aws-sdk:
         applies-to: version-updates
         patterns:
@@ -33,5 +28,4 @@ updates:
           - "cdk"
           - "constructs"
         update-types:
-          - "patch"
           - "minor"

--- a/.github/workflows/dependabot-auto-merge-pr.yml
+++ b/.github/workflows/dependabot-auto-merge-pr.yml
@@ -1,0 +1,31 @@
+name: Dependabot auto-approve PR
+on: 
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'thesuavehog/aws-sns-to-google-chat-space'
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Approve a PR
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' && steps.metadata.outputs.dependency-group == 'patches'
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: Enable auto-merge for Dependabot PRs
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' && steps.metadata.outputs.dependency-group == 'patches'
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Add CI workflows to automatically approve and enable auto-merge PRs from dependabot which contain only patch updates. 

The status checks must pass before the auto-merge will actually execute the merge operation. This is controlled in the repository settings for the `main` branch.