### PR TITLE
Fix dependabot auto merge permissions

### DIFF
--- a/.github/workflows/dependabot-auto-merge-pr.yml
+++ b/.github/workflows/dependabot-auto-merge-pr.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   pull-requests: write
+  contents: write
 
 jobs:
   dependabot:


### PR DESCRIPTION
Fixes #131

Add necessary permissions to enable auto-merge for Dependabot PRs.

* Add `contents: write` to the `permissions` section in `.github/workflows/dependabot-auto-merge-pr.yml`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/thesuavehog/aws-sns-to-google-chat-space/pull/132?shareId=c4f14556-b160-4a37-8761-022707ba0503).